### PR TITLE
Expand dependency bounds to support recent dep. versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-#  claude-haskell 
+#  claude-haskell
 
 [![License: MIT](https://cdn.prod.website-files.com/5e0f1144930a8bc8aace526c/65dd9eb5aaca434fac4f1c34_License-MIT-blue.svg)](/LICENSE)
 ![example workflow](https://github.com/T0mLam/claude-haskell/actions/workflows/haskell.yml/badge.svg)
@@ -17,7 +17,7 @@ This library provides Haskell functions to interact with the Claude API, includi
     - [List all available models](#list-all-available-models)
     - [Get model details](#get-model-details)
     - [Message batch operations](#message-batch-operations)
-    - [Create custom requests to Anthropic's API](#create-custom-requests-to-anthropics-api)  
+    - [Create custom requests to Anthropic's API](#create-custom-requests-to-anthropics-api)
 - [Modules](#modules)
     - [**ClaudeAPI.Config**](#claudeapiconfig)
         - [baseUrl](#baseurl)
@@ -112,7 +112,7 @@ This library provides Haskell functions to interact with the Claude API, includi
    ├── app
    │   └── Main.hs
    ├── cabal.project
-   ├── .env # Create a new environment file 
+   ├── .env # Create a new environment file
    └── new-project.cabal
    ```
    `.env`
@@ -120,7 +120,7 @@ This library provides Haskell functions to interact with the Claude API, includi
    ```bash
    API_KEY=<api_key>
    ANTHROPIC_VERSION=<anthropic_version> # e.g. 2023-06-01
-   ``` 
+   ```
 
 ## Usage
 
@@ -128,7 +128,7 @@ Below is a guide to the key functionalities and corresponding functions.
 
 ### Send messages
 
-[`chat`](#chat) [`defaultChatRequest`](#defaultchatrequest)   [`defaultIOImageChatRequest`](#defaultioimagechatrequest) [`ChatRequest`](#chatrequest)
+[`chat`](#chat) [`defaultChatRequest`](#defaultchatrequest)   [`defaultIOMediaChatRequest`](#defaultiomediachatrequest) [`ChatRequest`](#chatrequest)
 
 ```haskell
 chat :: ChatRequest -> IO (Either String ChatResponse)
@@ -141,8 +141,8 @@ defaultChatRequest
 ```
 
 ```haskell
-defaultIOMediaChatRequest 
-    :: String -- File path (i.e. local, URL)
+defaultIOMediaChatRequest
+    :: FilePath -- File path (i.e. local, URL)
     -> String -- Instructions
     -> IO (Either String ChatRequest)
 ```
@@ -185,7 +185,7 @@ main = do
     let imagePath = "https://thumbs.dreamstime.com/b/red-apple-isolated-clipping-path-19130134.jpg"
     let instructions = "What is in this image?"
 
-    -- Encode the image into base64 format 
+    -- Encode the image into base64 format
     result <- defaultIOImageChatRequest imagePath instructions
 
     case result of
@@ -289,31 +289,31 @@ getModel :: String -> IO (Either String ModelData)
 
 
 ```haskell
-createMessageBatch 
-    :: MessageBatchRequests 
+createMessageBatch
+    :: MessageBatchRequests
     -> IO (Either String MessageBatchResponse)
 ```
 
 ```haskell
-retrieveMessageBatch 
+retrieveMessageBatch
     :: String -- Message batch ID, e.g. msg_...
     -> IO (Either String MessageBatchResponse)
 ```
 
 ```haskell
-listMessageBatch 
-    :: ListMessageBatchRequest 
+listMessageBatch
+    :: ListMessageBatchRequest
     -> IO (Either String ListMessageBatchResponse)
 ```
 
 ```haskell
-cancelMessageBatch 
+cancelMessageBatch
     :: String -- Message batch ID, e.g. msg_...
     -> IO (Either String MessageBatchResponse)
 ```
 
 ```haskell
-retrieveMessageBatchResults 
+retrieveMessageBatchResults
     :: String -- Message batch ID, e.g. msg_...
     -> IO (Either String RetrieveMessageBatchResults)
 ```
@@ -326,23 +326,23 @@ retrieveMessageBatchResults
 
 ```haskell
 sendRequest
-    :: (ToJSON req, JSONResponse resp) 
+    :: (ToJSON req, JSONResponse resp)
     => String -- request method
     -> String -- endpoint
-    -> Maybe req 
+    -> Maybe req
     -> IO (Either String resp)
 ```
 
 **Example:**
 
 ```haskell
-data ExampleReq = ExampleReq {...} 
+data ExampleReq = ExampleReq {...}
     deriving (Show, Generic, ToJson)
 
 -- JSONResponse is a subclass of FromJSON,
--- which determines how the content is decoded 
--- to the data object (default=Data.Aeson.eitherDecode) 
-data ExampleResp = ExampleResp {...} 
+-- which determines how the content is decoded
+-- to the data object (default=Data.Aeson.eitherDecode)
+data ExampleResp = ExampleResp {...}
     deriving (Show, Generic, JSONResponse)
 
 exampleFunc :: ExampleReq -> IO (Either String ExampleResp)
@@ -532,7 +532,7 @@ Creates a default `ChatRequest` for media files (e.g., images or documents).
 
 **Type:**
 ```haskell
-defaultIOMediaChatRequest :: String -> String -> IO (Either String ChatRequest)
+defaultIOMediaChatRequest :: FilePath -> String -> IO (Either String ChatRequest)
 ```
 
 **Parameters:**
@@ -1130,7 +1130,7 @@ This module provides utility functions and type classes for handling query param
 Defines a type class for types that can provide query parameters for HTTP requests.
 
 ```haskell
-class HasQueryParams a where 
+class HasQueryParams a where
     getBeforeID :: a -> Maybe String
     -- ^ Retrieves the `before_id` query parameter, if present.
 
@@ -1204,4 +1204,4 @@ Contributions are welcome! Please follow these steps:
 
 ## License
 
-This library is licensed under the MIT License. 
+This library is licensed under the MIT License.

--- a/claude-haskell.cabal
+++ b/claude-haskell.cabal
@@ -79,12 +79,12 @@ library
     -- other-extensions:
 
     -- Other library packages from which modules are imported.
-    build-depends:    
-        base ^>=4.17.2.1,
+    build-depends:
+        base >=4.17 && < 4.22,
         aeson >= 2.2.3 && < 2.3,
-        bytestring >= 0.11.5 && < 0.12,
-        filepath >= 1.4.2 && < 1.5,
-        text >= 2.0.2 && < 2.1,
+        bytestring >= 0.11.5 && < 0.13,
+        filepath >= 1.4.2 && < 1.6,
+        text >= 2.0.2 && < 2.2,
         vector >= 0.13.2 && < 0.14,
         directory >= 1.3.7 && < 1.4,
         base64-bytestring >= 1.2.1 && < 1.3,
@@ -127,6 +127,6 @@ test-suite claude-haskell-test
 
     -- Test dependencies.
     build-depends:
-        base ^>=4.17.2.1,
+        base >=4.17 && < 4.22,
         claude-haskell,
         hspec

--- a/claude-haskell.cabal
+++ b/claude-haskell.cabal
@@ -50,6 +50,7 @@ extra-doc-files:    CHANGELOG.md
 
 -- Extra source files to be distributed with the package, such as examples, or a tutorial module.
 -- extra-source-files:
+tested-with:        GHC == 9.4.8
 
 source-repository head
     type:     git
@@ -63,7 +64,7 @@ library
     import:           warnings
 
     -- Modules exported by the library.
-    exposed-modules:  
+    exposed-modules:
         ClaudeAPI.Chat
         ClaudeAPI.MessageBatches
         ClaudeAPI.Models

--- a/src/ClaudeAPI.hs
+++ b/src/ClaudeAPI.hs
@@ -1,11 +1,11 @@
 {-# LANGUAGE DuplicateRecordFields #-}
 
 module ClaudeAPI
-( -- Configurations
+( -- ** Configurations
   baseUrl
 , defaultModel
 
-  -- Send messages to Claude
+  -- ** Send messages to Claude
 , defaultChatRequest
 , defaultCountTokenRequest
 , defaultIOMediaChatRequest
@@ -19,19 +19,19 @@ module ClaudeAPI
 , encodeMediaToBase64
 , addMediaToChatRequest
 
-  -- Send message batches to Claude
+  -- ** Send message batches to Claude
 , createMessageBatch
 , retrieveMessageBatch
 , listMessageBatch
 , cancelMessageBatch
 , retrieveMessageBatchResults
 
-  -- Get model info
+  -- ** Get model info
 , listModels
 , getModel
 , defaultModelRequest
 
-  -- Types
+  -- ** Types
 , MediaSource (..)
 , RequestMessageContent (..)
 , RequestMessage (..)
@@ -52,7 +52,7 @@ module ClaudeAPI
 , MessageBatchResult (..)
 , RetrieveMessageBatchResult (..)
 
-  -- Utility functions for building data types
+  -- ** Utility functions for building data types
 , camelToUnderscore
 , buildQueryString
 )

--- a/src/ClaudeAPI.hs
+++ b/src/ClaudeAPI.hs
@@ -1,4 +1,6 @@
-module ClaudeAPI 
+{-# LANGUAGE DuplicateRecordFields #-}
+
+module ClaudeAPI
 ( -- Configurations
   baseUrl
 , defaultModel
@@ -29,7 +31,7 @@ module ClaudeAPI
 , getModel
 , defaultModelRequest
 
-  -- Types 
+  -- Types
 , MediaSource (..)
 , RequestMessageContent (..)
 , RequestMessage (..)
@@ -52,8 +54,8 @@ module ClaudeAPI
 
   -- Utility functions for building data types
 , camelToUnderscore
-, buildQueryString   
-) 
+, buildQueryString
+)
 where
 
 import ClaudeAPI.Config (baseUrl, defaultModel)
@@ -76,8 +78,8 @@ import ClaudeAPI.MessageBatches
     , createMessageBatch
     , listMessageBatch
     , retrieveMessageBatch
-    , retrieveMessageBatchResults 
-    ) 
+    , retrieveMessageBatchResults
+    )
 import ClaudeAPI.Models (listModels, getModel, defaultModelRequest)
 import ClaudeAPI.Types
     ( MediaSource (..)
@@ -99,8 +101,8 @@ import ClaudeAPI.Types
     , ListMessageBatchResponse (..)
     , MessageBatchResult (..)
     , RetrieveMessageBatchResult (..)
-    ) 
-import ClaudeAPI.Utils 
+    )
+import ClaudeAPI.Utils
     ( camelToUnderscore
-    , buildQueryString   
+    , buildQueryString
     )

--- a/src/ClaudeAPI/Chat.hs
+++ b/src/ClaudeAPI/Chat.hs
@@ -51,8 +51,8 @@ defaultChatRequest reqContent = ChatRequest
 -- | Send any request to the Claude API
 sendRequest
     :: (ToJSON req, JSONResponse resp)
-    => String -- ^ request method, like "POST" or "GET"
-    -> String -- ^ endpoint, like "/v1/messages"
+    => String -- ^ request method, like \"POST\" or \"GET\"
+    -> String -- ^ endpoint, like \"\/v1\/messages\"
     -> Maybe req
     -> IO (Either String resp)
 sendRequest requestMethod endpoint chatReq = do

--- a/src/ClaudeAPI/Chat.hs
+++ b/src/ClaudeAPI/Chat.hs
@@ -114,7 +114,11 @@ chat :: ChatRequest -> IO (Either String ChatResponse)
 chat req = sendRequest "POST" "/v1/messages" (Just req)
 
 
-addMessageToChatRequest :: String -> String -> ChatRequest -> ChatRequest
+addMessageToChatRequest
+    :: String -- ^ role, like "user" or "assistant"
+    -> String -- ^ message content
+    -> ChatRequest
+    -> ChatRequest
 addMessageToChatRequest r m req =
     req { messages = messages req ++ [RequestMessage { role = r, content = Left m }] }
 

--- a/src/ClaudeAPI/Chat.hs
+++ b/src/ClaudeAPI/Chat.hs
@@ -189,7 +189,7 @@ encodeMediaToBase64 mediaPath = do
                     return $ Right $ decodeUtf8 mediaBytesB64
 
 
-defaultIOMediaChatRequest :: String -> String -> IO (Either String ChatRequest)
+defaultIOMediaChatRequest :: FilePath -> String -> IO (Either String ChatRequest)
 defaultIOMediaChatRequest mediaPath message = do
     let mediaType' = getMediaType mediaPath
     let msgType' = if mediaType' == "application/pdf" then "document" else "image"
@@ -222,7 +222,7 @@ defaultIOMediaChatRequest mediaPath message = do
                 }
 
 
-addMediaToChatRequest :: String -> String -> ChatRequest -> IO (Either String ChatRequest)
+addMediaToChatRequest :: FilePath -> String -> ChatRequest -> IO (Either String ChatRequest)
 addMediaToChatRequest mediaPath message req = do
     imageRequest <- defaultIOMediaChatRequest mediaPath message
     case imageRequest of

--- a/src/ClaudeAPI/Chat.hs
+++ b/src/ClaudeAPI/Chat.hs
@@ -15,7 +15,7 @@ import ClaudeAPI.Types
     )
 import ClaudeAPI.Config (baseUrl, defaultModel)
 
-import Configuration.Dotenv (loadFile, defaultConfig)  
+import Configuration.Dotenv (loadFile, defaultConfig)
 import Control.Exception (SomeException, try)
 import Data.Aeson (encode, ToJSON)
 import Control.Monad (when)
@@ -23,7 +23,7 @@ import Data.Char (toLower)
 import Data.List (isPrefixOf)
 import Data.Text (Text)
 import Data.Text.Encoding (decodeUtf8)
-import Network.HTTP.Client 
+import Network.HTTP.Client
 import Network.HTTP.Client.TLS (tlsManagerSettings)
 import Network.HTTP.Types.Status (statusCode, Status (statusMessage))
 import System.Environment (getEnv)
@@ -37,7 +37,7 @@ import qualified Data.CaseInsensitive as CI
 
 
 defaultChatRequest :: String -> ChatRequest
-defaultChatRequest reqContent = ChatRequest 
+defaultChatRequest reqContent = ChatRequest
     { model = defaultModel
     , messages = [RequestMessage { role = "user", content = Left reqContent }]
     , maxTokens = 1024
@@ -48,12 +48,12 @@ defaultChatRequest reqContent = ChatRequest
     }
 
 
--- Send any request to the Claude API
+-- | Send any request to the Claude API
 sendRequest
-    :: (ToJSON req, JSONResponse resp) 
-    => String -- request method
-    -> String -- endpoint
-    -> Maybe req 
+    :: (ToJSON req, JSONResponse resp)
+    => String -- ^ request method, like "POST" or "GET"
+    -> String -- ^ endpoint, like "/v1/messages"
+    -> Maybe req
     -> IO (Either String resp)
 sendRequest requestMethod endpoint chatReq = do
     -- Try to load the API key from the .env file
@@ -63,7 +63,7 @@ sendRequest requestMethod endpoint chatReq = do
     getApiKey <- try (getEnv "API_KEY") :: IO (Either SomeException String)
     getAnthropicVersion <- try (getEnv "ANTHROPIC_VERSION") :: IO (Either SomeException String)
 
-    case (getApiKey, getAnthropicVersion) of 
+    case (getApiKey, getAnthropicVersion) of
         (Left _, _) -> return $ Left "error: API key not found"
         (_, Left _) -> return $ Left "error: Anthropic version not found"
         (Right apiKey, Right anthropicVersion) -> do
@@ -76,7 +76,7 @@ sendRequest requestMethod endpoint chatReq = do
             -- Encode the request as JSON
             let claudeRequestBody = maybe mempty (RequestBodyLBS . encode) chatReq
 
-            -- Create the request object 
+            -- Create the request object
             let request = initialRequest
                     { requestHeaders = fmap (\(k, v) -> (CI.mk $ BS.pack k, BS.pack v))
                         [ ("Content-Type", "application/json")
@@ -98,51 +98,51 @@ sendRequest requestMethod endpoint chatReq = do
                     -- Decode the json or jsonl response into data object
                     Right responseBodyObject -> return $ Right responseBodyObject
                     Left err -> return $ Left $ "error: failed to decode response body" ++ err
-                    
-                code -> do 
+
+                code -> do
                     -- Decode the error response body into a string
                     let errorDetails = BL.unpack responseBody'
                     let responseStatusMessage' = statusMessage responseStatus'
-                    return $ 
-                        Left $ 
-                            "error " ++ show code ++ ": " 
-                            ++ BS.unpack responseStatusMessage' 
+                    return $
+                        Left $
+                            "error " ++ show code ++ ": "
+                            ++ BS.unpack responseStatusMessage'
                             ++ ". " ++ errorDetails
 
 
 chat :: ChatRequest -> IO (Either String ChatResponse)
 chat req = sendRequest "POST" "/v1/messages" (Just req)
- 
+
 
 addMessageToChatRequest :: String -> String -> ChatRequest -> ChatRequest
-addMessageToChatRequest r m req = 
+addMessageToChatRequest r m req =
     req { messages = messages req ++ [RequestMessage { role = r, content = Left m }] }
 
 
 addResponseToChatRequest :: ChatRequest -> ChatResponse -> ChatRequest
-addResponseToChatRequest req resp = 
-    let 
+addResponseToChatRequest req resp =
+    let
         respRole = responseRole resp
         respContent = responseText $ head $ responseContent resp
-    in 
+    in
         addMessageToChatRequest respRole respContent req
 
-    
+
 defaultCountTokenRequest :: String -> CountTokenRequest
-defaultCountTokenRequest reqContent = CountTokenRequest 
+defaultCountTokenRequest reqContent = CountTokenRequest
     { model = defaultModel
     , requestMessages = [RequestMessage { role = "user", content = Left reqContent }]
     , system = Nothing
     }
 
-    
+
 countToken :: CountTokenRequest -> IO (Either String CountTokenResponse)
 countToken req = sendRequest "POST" "/v1/messages/count_tokens" (Just req)
 
 
 getMediaType :: FilePath -> String
 getMediaType mediaPath =
-    case map toLower (takeExtension mediaPath) of 
+    case map toLower (takeExtension mediaPath) of
         ".pdf" ->  "application/pdf"
         ".jpg" -> "image/jpeg"
         other -> "image/" ++ drop 1 other
@@ -151,7 +151,7 @@ getMediaType mediaPath =
 encodeMediaToBase64 :: String -> IO (Either String Text)
 encodeMediaToBase64 mediaPath = do
     if  "https://" `isPrefixOf` mediaPath
-        then do 
+        then do
             -- Fetch online media
             -- Create a new HTTP manager
             manager <- newManager tlsManagerSettings
@@ -169,8 +169,8 @@ encodeMediaToBase64 mediaPath = do
                     let mediaBytes = responseBody response
                     let mediaBytesB64 = B64.encode (BL.toStrict mediaBytes)
                     return $ Right $ decodeUtf8 mediaBytesB64
-                            
-                code -> do 
+
+                code -> do
                     -- Decode the error response body into a string
                     let errorDetails = BL.unpack responseBody'
                     let responseStatusMessage' = statusMessage responseStatus'
@@ -184,30 +184,30 @@ encodeMediaToBase64 mediaPath = do
                 then return $ Left "error: File does not exist."
                 else do
                     -- Encode the media into base64 format
-                    mediaBytes <- BS.readFile mediaPath 
+                    mediaBytes <- BS.readFile mediaPath
                     let mediaBytesB64 = B64.encode mediaBytes
                     return $ Right $ decodeUtf8 mediaBytesB64
-        
+
 
 defaultIOMediaChatRequest :: String -> String -> IO (Either String ChatRequest)
 defaultIOMediaChatRequest mediaPath message = do
     let mediaType' = getMediaType mediaPath
     let msgType' = if mediaType' == "application/pdf" then "document" else "image"
     encodedMediaResult <- encodeMediaToBase64 mediaPath
-    case encodedMediaResult of 
+    case encodedMediaResult of
         Left err -> return $ Left err
         Right encodedMedia -> do
-            let mediaSource = MediaSource 
+            let mediaSource = MediaSource
                     { encodingType = "base64"
                     , mediaType = mediaType'
                     , imageData = encodedMedia
                     }
-            return $ Right ChatRequest 
+            return $ Right ChatRequest
                 { model = defaultModel
-                , messages = 
+                , messages =
                     [ RequestMessage
                         { role = "user"
-                        , content = 
+                        , content =
                             Right
                                 [ MediaContent { msgType = msgType', source = mediaSource }
                                 , TextContent { msgType = "text", text = message }
@@ -236,32 +236,32 @@ chatBot = do
     let req = defaultChatRequest "Hi Claude."
     chatHelper req
 
-    where 
+    where
         chatHelper :: ChatRequest -> IO ()
         chatHelper chatReq = do
             -- Send the initial request to Claude
             resp <- chat chatReq
 
-            case resp of 
+            case resp of
                 Left err -> putStrLn err
                 Right chatResp -> do
                     -- Add Claude's response into the new request
                     let respContent =
                             responseText $ head $ responseContent chatResp
 
-                    let updatedChatReq = 
+                    let updatedChatReq =
                             addResponseToChatRequest chatReq chatResp
 
                     putStrLn $ "Claude:\n-------\n" ++ respContent ++ "\n"
 
-                    putStrLn "You:\n----"  
+                    putStrLn "You:\n----"
                     userReply <- getLine
                     putStrLn ""
 
-                    case userReply of 
+                    case userReply of
                         "CLEAR" -> do
                             -- Empty chat history
-                            putStrLn "You:\n----"  
+                            putStrLn "You:\n----"
                             newMessage <- getLine
                             putStrLn ""
                             chatHelper $ defaultChatRequest newMessage
@@ -270,7 +270,7 @@ chatBot = do
                                 then do
                                     -- New media message
                                     -- Get the instructions for the media request.
-                                    putStr "Instructions: "  
+                                    putStr "Instructions: "
                                     instructions <- getLine
                                     putStrLn ""
 
@@ -281,9 +281,9 @@ chatBot = do
                                     case mediaRequest of
                                         Left err -> putStrLn err
                                         Right newChatReq -> chatHelper newChatReq
-                                else do 
+                                else do
                                     -- New text message
-                                    let newChatReq = 
+                                    let newChatReq =
                                             addMessageToChatRequest "user" userReply updatedChatReq
                                     chatHelper newChatReq
 

--- a/src/ClaudeAPI/Config.hs
+++ b/src/ClaudeAPI/Config.hs
@@ -8,5 +8,7 @@ baseUrl = "https://api.anthropic.com"
 -- | Default model to use for requests (\"claude-3-5-sonnet-20241022\")
 --
 -- See [model names](https://docs.anthropic.com/en/docs/about-claude/models/overview#model-names) for other possibilities.
+--
+-- You can also use the 'listModels' function to get an up-to-date list of available models.
 defaultModel :: String
 defaultModel = "claude-3-5-sonnet-20241022"

--- a/src/ClaudeAPI/Config.hs
+++ b/src/ClaudeAPI/Config.hs
@@ -1,7 +1,12 @@
 module ClaudeAPI.Config where
 
+-- | Base URL for the Anthropic API.
 baseUrl :: String
 baseUrl = "https://api.anthropic.com"
 
-defaultModel :: String 
+
+-- | Default model to use for requests (\"claude-3-5-sonnet-20241022\")
+--
+-- See [model names](https://docs.anthropic.com/en/docs/about-claude/models/overview#model-names) for other possibilities.
+defaultModel :: String
 defaultModel = "claude-3-5-sonnet-20241022"


### PR DESCRIPTION
Hello,
thanks for sharing this library! It would be great if the dependency bounds were a bit less strict, so it would be possible to build it with more recent GHC versions.
I executed `cabal outdated` to identify too-restrictive version bounds and bumped all of them to make the lib buildable with the latest available dependencies.

I would also recommend generating CI config for all supported GHC versions using [haskell-ci](https://github.com/haskell-CI/haskell-ci).
But I saw that your CI config is actually running tests against live anthropic API, which might be undesirable to do with all tested GHC versions..

EDIT: I ended up doing few more haddock and backward compatible api improvements (like use FilePath for image/media file paths in few places).
